### PR TITLE
new migration to make cocktailingredient join table with amounts

### DIFF
--- a/Api/SavedCocktailApi.cs
+++ b/Api/SavedCocktailApi.cs
@@ -13,7 +13,8 @@ namespace CocktailClub.Api
             {
                 List<SavedCocktail> savedCocktails = db.SavedCocktails
                 .Include(c => c.Glass)
-                .Include(c => c.Ingredients)
+                .Include(c => c.CocktailIngredients)
+                .ThenInclude(ci => ci.Ingredient)
                 .Where(c => c.UserId == userId).ToList();
                 if (savedCocktails == null)
                 {
@@ -31,7 +32,8 @@ namespace CocktailClub.Api
             {
                 List<SavedCocktail> publicCocktails = db.SavedCocktails
                 .Include(c => c.Glass)
-                .Include(c => c.Ingredients)
+                .Include(c => c.CocktailIngredients)
+                .ThenInclude(ci => ci.Ingredient)
                 .Where(c => c.Public == true).ToList();
                 if (publicCocktails == null)
                 {
@@ -49,7 +51,9 @@ namespace CocktailClub.Api
             {
                 SavedCocktail cocktail = db.SavedCocktails
                 .Include (c => c.Glass)
-                .Include(c => c.Ingredients).SingleOrDefault(c => c.Id == id);
+                .Include(c => c.CocktailIngredients)
+                .ThenInclude (ci => ci.Ingredient)
+                .SingleOrDefault(c => c.Id == id);
                 if (cocktail == null)
                 {
                     return Results.NotFound("No cocktail found");
@@ -99,7 +103,8 @@ namespace CocktailClub.Api
             {
                 SavedCocktail cocktailToUpdate = db.SavedCocktails
                 .Include(c => c.Glass)
-                .Include(c => c.Ingredients)
+                .Include(c => c.CocktailIngredients)
+                .ThenInclude(ci => ci.Ingredient)
                 .SingleOrDefault(c => c.Id == cocktail.Id);
                 if (cocktailToUpdate == null)
                 {
@@ -111,7 +116,7 @@ namespace CocktailClub.Api
                 cocktailToUpdate.Grade = cocktail.Grade;
                 cocktailToUpdate.GlassId = cocktail.GlassId;
                 cocktailToUpdate.Instructions = cocktail.Instructions;
-                cocktailToUpdate.Ingredients = cocktail.Ingredients;
+                cocktailToUpdate.CocktailIngredients = cocktail.CocktailIngredients;
 
                 db.SaveChanges();
                 return Results.Ok("cocktail updated");
@@ -138,7 +143,7 @@ namespace CocktailClub.Api
                     UserId = userId,
                     Name = publicCocktail.Name,
                     Instructions = publicCocktail.Instructions,
-                    Ingredients = publicCocktail.Ingredients,
+                    CocktailIngredients = publicCocktail.CocktailIngredients,
                     GlassId = publicCocktail.GlassId,
                     DrinkId = publicCocktail.DrinkId,
                 };

--- a/CCDbContext.cs
+++ b/CCDbContext.cs
@@ -11,6 +11,8 @@ namespace CocktailClub
         public DbSet<Spirit> Spirits { get; set; }
         public DbSet<User> Users { get; set; }
 
+        public DbSet<CocktailIngredient> CocktailIngredients { get; set; }
+
         public CCDbContext(DbContextOptions<CCDbContext> context) : base(context)
         {
 

--- a/Migrations/20240525162535_dbUpdate.Designer.cs
+++ b/Migrations/20240525162535_dbUpdate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CocktailClub;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CocktailClub.Migrations
 {
     [DbContext(typeof(CCDbContext))]
-    partial class CCDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240525162535_dbUpdate")]
+    partial class dbUpdate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20240525162535_dbUpdate.cs
+++ b/Migrations/20240525162535_dbUpdate.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace CocktailClub.Migrations
+{
+    /// <inheritdoc />
+    public partial class dbUpdate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IngredientSavedCocktail");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "DrinkId",
+                table: "SavedCocktails",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.CreateTable(
+                name: "CocktailIngredients",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Amount = table.Column<string>(type: "text", nullable: false),
+                    IngredientId = table.Column<int>(type: "integer", nullable: false),
+                    SavedCocktailId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CocktailIngredients", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CocktailIngredients_Ingredients_IngredientId",
+                        column: x => x.IngredientId,
+                        principalTable: "Ingredients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CocktailIngredients_SavedCocktails_SavedCocktailId",
+                        column: x => x.SavedCocktailId,
+                        principalTable: "SavedCocktails",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CocktailIngredients_IngredientId",
+                table: "CocktailIngredients",
+                column: "IngredientId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CocktailIngredients_SavedCocktailId",
+                table: "CocktailIngredients",
+                column: "SavedCocktailId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CocktailIngredients");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "DrinkId",
+                table: "SavedCocktails",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "IngredientSavedCocktail",
+                columns: table => new
+                {
+                    IngredientsId = table.Column<int>(type: "integer", nullable: false),
+                    SavedCocktailsId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IngredientSavedCocktail", x => new { x.IngredientsId, x.SavedCocktailsId });
+                    table.ForeignKey(
+                        name: "FK_IngredientSavedCocktail_Ingredients_IngredientsId",
+                        column: x => x.IngredientsId,
+                        principalTable: "Ingredients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_IngredientSavedCocktail_SavedCocktails_SavedCocktailsId",
+                        column: x => x.SavedCocktailsId,
+                        principalTable: "SavedCocktails",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IngredientSavedCocktail_SavedCocktailsId",
+                table: "IngredientSavedCocktail",
+                column: "SavedCocktailsId");
+        }
+    }
+}

--- a/Models/CocktailIngredient.cs
+++ b/Models/CocktailIngredient.cs
@@ -1,0 +1,10 @@
+﻿namespace CocktailClub.Models
+{
+    public class CocktailIngredient
+    {
+        public int Id { get; set; }
+        public string Amount { get; set; }
+        public Ingredient Ingredient { get; set; }
+        public SavedCocktail SavedCocktail { get; set; }
+    }
+}

--- a/Models/Ingredient.cs
+++ b/Models/Ingredient.cs
@@ -4,6 +4,6 @@
     {
         public int Id { get; set; }
         public string Name { get; set; }
-        public ICollection<SavedCocktail> SavedCocktails { get; set; }
+        public List<CocktailIngredient> CocktailIngredients { get; set; } = new List<CocktailIngredient>();
     }
 }

--- a/Models/SavedCocktail.cs
+++ b/Models/SavedCocktail.cs
@@ -14,7 +14,7 @@
         public string? Notes { get; set; }
         public bool Made { get; set; }
         public bool Public { get; set; }
-        public ICollection<Ingredient> Ingredients { get; set; }
+        public List<CocktailIngredient> CocktailIngredients { get; set; } = new List<CocktailIngredient>();
 
     }
 }


### PR DESCRIPTION
## Description
My original data design planned on putting ingredient and ingredient amount in same string, but further work with data proved this to be a faulty design (you would save the same ingredient with different amounts infinite times, presenting a pk error in the db).

Data structure was changed to create a join table representing the cocktail ingredient in specific drink, with an amount property. Thus I needed to manually add the join table and do a new migration.

## Related Issue
#9 

## Motivation and Context
avoids having to create new amount entity and avoids duplicate key errors for cocktail ingredients

## How Can This Be Tested?
swagger

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
